### PR TITLE
Add data archive export/import and reports

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,13 @@
           <option value="za">Z-A</option>
         </select>
       </div>
+      <div class="export-buttons">
+        <button id="exportarJson" class="secondary" aria-label="Exportar histórico">Exportar</button>
+        <button id="importarJson" class="secondary" aria-label="Importar histórico">Importar</button>
+        <button id="exportarExcel" class="secondary" aria-label="Exportar para Excel">Excel</button>
+        <button id="exportarPdf" class="secondary" aria-label="Exportar para PDF">PDF</button>
+      </div>
+      <input type="file" id="arquivoImportar" accept="application/json" style="display:none;" />
       <div id="listaHistorico" class="lista-historico"></div>
     </div>
     <div id="storageUsage" class="storage-usage">0 MB / 5 MB</div>

--- a/style.css
+++ b/style.css
@@ -200,6 +200,29 @@ h1 {
   padding: 0.3rem;
 }
 
+.export-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0.5rem 0;
+}
+
+.export-buttons button {
+  flex: 1;
+  padding: 0.5rem;
+  border: none;
+  border-radius: 4px;
+  background-color: #6c757d;
+  color: #fff;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: background-color 0.2s;
+}
+
+.export-buttons button:hover:not(:disabled) {
+  background-color: #5a6268;
+}
+
 .lista-historico {
   display: flex;
   gap: 0.5rem;


### PR DESCRIPTION
## Summary
- add buttons to export/import history and to generate Excel/PDF
- style new export buttons
- implement JSON export/import and Excel/PDF generation in JavaScript
- record historical entries using pt-BR date format

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_6856be578cac8329af47446174d7abe9